### PR TITLE
Feature/ingredient

### DIFF
--- a/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
+++ b/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
@@ -1,6 +1,8 @@
 package com.example.dream_of_refrigerator.controller.ingredient;
 
+import com.example.dream_of_refrigerator.domain.user.UserIngredient;
 import com.example.dream_of_refrigerator.dto.ingredient.BasicIngredientDto;
+import com.example.dream_of_refrigerator.dto.ingredient.UserIngredientDto;
 import com.example.dream_of_refrigerator.service.ingredient.IngredientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +33,14 @@ public class IngredientController {
     public ResponseEntity<List<BasicIngredientDto>> searchIngredients(@RequestParam String query) {
         List<BasicIngredientDto> ingredients = ingredientService.searchIngredients(query);
         return ResponseEntity.ok(ingredients);
+    }
+
+    //재료 등록
+    @PostMapping("/{ingredientId}")
+    public ResponseEntity<UserIngredientDto> registerIngredients(@PathVariable("ingredientId") Long ingredientId,
+                                                                 @RequestBody UserIngredientDto userIngredientDto){
+        UserIngredient userIngredient=ingredientService.registerIngredients(ingredientId,userIngredientDto);
+        return  ResponseEntity.ok(userIngredient.toDto());
     }
 
     // 재료 정보 상세조회

--- a/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
+++ b/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
@@ -1,8 +1,7 @@
-package com.example.dream_of_refrigerator.controller;
+package com.example.dream_of_refrigerator.controller.ingredient;
 
-import com.example.dream_of_refrigerator.dto.BasicIngredientDto;
-import com.example.dream_of_refrigerator.dto.DetailIngredientDto;
-import com.example.dream_of_refrigerator.service.IngredientService;
+import com.example.dream_of_refrigerator.dto.ingredient.BasicIngredientDto;
+import com.example.dream_of_refrigerator.service.ingredient.IngredientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
+++ b/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
@@ -2,7 +2,7 @@ package com.example.dream_of_refrigerator.controller.ingredient;
 
 import com.example.dream_of_refrigerator.domain.user.UserIngredient;
 import com.example.dream_of_refrigerator.dto.ingredient.BasicIngredientDto;
-import com.example.dream_of_refrigerator.dto.ingredient.UserIngredientDto;
+import com.example.dream_of_refrigerator.dto.ingredient.request.UserIngredientRequestDto;
 import com.example.dream_of_refrigerator.service.ingredient.IngredientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,13 +35,15 @@ public class IngredientController {
         return ResponseEntity.ok(ingredients);
     }
 
-    //재료 등록
+    //재료 등록(재료 검색 페이지에서 특정 재료 클릭할 경우 실행)
     @PostMapping("/{ingredientId}")
-    public ResponseEntity<UserIngredientDto> registerIngredients(@PathVariable("ingredientId") Long ingredientId,
-                                                                 @RequestBody UserIngredientDto userIngredientDto){
-        UserIngredient userIngredient=ingredientService.registerIngredients(ingredientId,userIngredientDto);
+    public ResponseEntity<UserIngredientRequestDto> registerIngredients(@PathVariable("ingredientId") Long ingredientId,
+                                                                        @RequestBody UserIngredientRequestDto userIngredientRequestDto){
+        UserIngredient userIngredient=ingredientService.registerIngredients(ingredientId, userIngredientRequestDto);
         return  ResponseEntity.ok(userIngredient.toDto());
     }
+
+
 
     // 재료 정보 상세조회
 /*

--- a/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
+++ b/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/IngredientController.java
@@ -43,15 +43,4 @@ public class IngredientController {
         return  ResponseEntity.ok(userIngredient.toDto());
     }
 
-
-
-    // 재료 정보 상세조회
-/*
-    @GetMapping("/{ingredientUuid}")
-    public ResponseEntity<List<DetailIngredientDto>> getIngredientDetailsByUuid(@PathVariable String ingredientUuid) {
-        List<DetailIngredientDto> ingredients = ingredientService.findAllDetails(ingredientUuid);
-        return ResponseEntity.ok(ingredients);
-    }
-*/
-
 }

--- a/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/UserIngredientController.java
+++ b/src/main/java/com/example/dream_of_refrigerator/controller/ingredient/UserIngredientController.java
@@ -1,0 +1,39 @@
+package com.example.dream_of_refrigerator.controller.ingredient;
+
+import com.example.dream_of_refrigerator.dto.ingredient.request.UserIngredientRequestDto;
+import com.example.dream_of_refrigerator.dto.ingredient.response.UserIngredientDetailResponseDto;
+import com.example.dream_of_refrigerator.dto.ingredient.response.UserIngredientResponseDto;
+import com.example.dream_of_refrigerator.service.ingredient.UserIngredientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/refrigerator/{userId}")
+@RequiredArgsConstructor
+public class UserIngredientController {
+    private final UserIngredientService userIngredientService;
+    //{nickname}의 냉장고의 nickname조회
+    @GetMapping("/nickname")
+    public ResponseEntity<String> getUserNickname(@PathVariable("userId") Long userId) {
+        String userNickname = userIngredientService.findUserNickname(userId);
+        return ResponseEntity.ok(userNickname);
+    }
+
+    //냉장고에 있는 모든 재료 조회 (expiration_date - purchase_date)의 차이가 짧은 순서로 정렬하여 조회
+    @GetMapping("/userIngredient")//정렬 기능 넣어야 함, 이름만 조회
+    public ResponseEntity<List<UserIngredientResponseDto>> getAllUserIngredient(@PathVariable("userId")Long userId) {
+        List<UserIngredientResponseDto> userIngredients = userIngredientService.findAll(userId);
+        return ResponseEntity.ok(userIngredients);
+    }
+
+    //냉장고에 있는 특정 재료 상세 조회
+    @GetMapping("userIngredient/{ingredientId}")
+    public ResponseEntity<UserIngredientDetailResponseDto> getDetailUserIngredient(@PathVariable("userId")Long userId,
+                                                                                    @PathVariable("ingredientId")Long ingredientId){
+        UserIngredientDetailResponseDto detailIngredient=userIngredientService.findDetail(userId,ingredientId);
+        return ResponseEntity.ok(detailIngredient);
+    }
+}

--- a/src/main/java/com/example/dream_of_refrigerator/domain/ingredient/Ingredient.java
+++ b/src/main/java/com/example/dream_of_refrigerator/domain/ingredient/Ingredient.java
@@ -35,6 +35,14 @@ public class Ingredient {
 
     @OneToMany(mappedBy = "ingredient")
     private List<IngredientRecipe> ingredientRecipes;
+
+    public void setIsFrozen(Boolean tf) {
+        this.isFrozen=tf;
+    }
+
+    public void setIsRefrigerated(Boolean tf) {
+        this.isRefrigerated=tf;
+    }
     /*
     long과 Long의 차이
     long : 원시타입 (null할당 불가능)

--- a/src/main/java/com/example/dream_of_refrigerator/domain/user/UserIngredient.java
+++ b/src/main/java/com/example/dream_of_refrigerator/domain/user/UserIngredient.java
@@ -1,8 +1,7 @@
 package com.example.dream_of_refrigerator.domain.user;
 
 import com.example.dream_of_refrigerator.domain.ingredient.Ingredient;
-import com.example.dream_of_refrigerator.domain.user.User;
-import com.example.dream_of_refrigerator.dto.ingredient.UserIngredientDto;
+import com.example.dream_of_refrigerator.dto.ingredient.request.UserIngredientRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -40,8 +39,8 @@ public class UserIngredient {
         this.purchaseDate = (purchaseDate != null) ? purchaseDate : LocalDate.now(); // 기본값 설정
         this.expirationDate = expirationDate;
     }
-    public UserIngredientDto toDto() {
-        return new UserIngredientDto(
+    public UserIngredientRequestDto toDto() {
+        return new UserIngredientRequestDto(
                 user.getId(),
                 ingredient.getId(),
                 ingredient.getCategory(),

--- a/src/main/java/com/example/dream_of_refrigerator/domain/user/UserIngredient.java
+++ b/src/main/java/com/example/dream_of_refrigerator/domain/user/UserIngredient.java
@@ -2,11 +2,9 @@ package com.example.dream_of_refrigerator.domain.user;
 
 import com.example.dream_of_refrigerator.domain.ingredient.Ingredient;
 import com.example.dream_of_refrigerator.domain.user.User;
+import com.example.dream_of_refrigerator.dto.ingredient.UserIngredientDto;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -33,4 +31,24 @@ public class UserIngredient {
     private LocalDate purchaseDate; // 구매 날짜
 
     private LocalDate expirationDate; // 유통기한
+
+    @Builder
+    public UserIngredient(Ingredient ingredient, User user, Integer quantity, LocalDate purchaseDate, LocalDate expirationDate) {
+        this.ingredient = ingredient;
+        this.user = user;
+        this.quantity = quantity;
+        this.purchaseDate = (purchaseDate != null) ? purchaseDate : LocalDate.now(); // 기본값 설정
+        this.expirationDate = expirationDate;
+    }
+    public UserIngredientDto toDto() {
+        return new UserIngredientDto(
+                user.getId(),
+                ingredient.getId(),
+                ingredient.getCategory(),
+                quantity,
+                purchaseDate,
+                expirationDate,
+                ingredient.getIsFrozen(),
+                ingredient.getIsRefrigerated());
+    }
 }

--- a/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/BasicIngredientDto.java
+++ b/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/BasicIngredientDto.java
@@ -1,4 +1,4 @@
-package com.example.dream_of_refrigerator.dto;
+package com.example.dream_of_refrigerator.dto.ingredient;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/DetailIngredientDto.java
+++ b/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/DetailIngredientDto.java
@@ -1,4 +1,4 @@
-package com.example.dream_of_refrigerator.dto;
+package com.example.dream_of_refrigerator.dto.ingredient;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/request/UserIngredientRequestDto.java
+++ b/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/request/UserIngredientRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.dream_of_refrigerator.dto.ingredient.request;
+
+import java.time.LocalDate;
+
+public record UserIngredientRequestDto(
+        Long UserId,
+        Long IngredientId,
+        String category,
+        Integer quantity,
+        LocalDate purchaseDate,
+        LocalDate expiredDate,
+        Boolean isFrozen,
+        Boolean isRefrigerated) {
+}

--- a/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/response/UserIngredientDetailResponseDto.java
+++ b/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/response/UserIngredientDetailResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.dream_of_refrigerator.dto.ingredient.response;
+
+import java.time.LocalDate;
+
+public record UserIngredientDetailResponseDto (
+        String name,
+        String category,
+        Integer quantity,
+        LocalDate purchaseDate,
+        LocalDate expiredDate,
+        Boolean isFrozen,
+        Boolean isRefrigerated)
+{
+}

--- a/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/response/UserIngredientResponseDto.java
+++ b/src/main/java/com/example/dream_of_refrigerator/dto/ingredient/response/UserIngredientResponseDto.java
@@ -1,0 +1,5 @@
+package com.example.dream_of_refrigerator.dto.ingredient.response;
+
+public record UserIngredientResponseDto(String ingredientName) {
+}
+//ingredientName : 재료 각각 이름

--- a/src/main/java/com/example/dream_of_refrigerator/repository/ingredient/IngredientRepository.java
+++ b/src/main/java/com/example/dream_of_refrigerator/repository/ingredient/IngredientRepository.java
@@ -1,4 +1,4 @@
-package com.example.dream_of_refrigerator.repository;
+package com.example.dream_of_refrigerator.repository.ingredient;
 
 import com.example.dream_of_refrigerator.domain.ingredient.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/dream_of_refrigerator/repository/ingredient/IngredientRepository.java
+++ b/src/main/java/com/example/dream_of_refrigerator/repository/ingredient/IngredientRepository.java
@@ -11,5 +11,6 @@ import java.util.List;
 @Repository
 public interface IngredientRepository extends JpaRepository<Ingredient,String>, JpaSpecificationExecutor<Ingredient> {
     List<Ingredient> findByCategory(String category);
+    Ingredient findById(Long id);
 
 }

--- a/src/main/java/com/example/dream_of_refrigerator/repository/ingredient/UserIngredientRepository.java
+++ b/src/main/java/com/example/dream_of_refrigerator/repository/ingredient/UserIngredientRepository.java
@@ -1,0 +1,13 @@
+package com.example.dream_of_refrigerator.repository.ingredient;
+
+import com.example.dream_of_refrigerator.domain.user.User;
+import com.example.dream_of_refrigerator.domain.user.UserIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserIngredientRepository extends JpaRepository<UserIngredient,Long> {
+    List<UserIngredient> findByUser(User user);
+    Optional<UserIngredient> findByUserAndIngredientId(User user, Long ingredientId);
+}

--- a/src/main/java/com/example/dream_of_refrigerator/repository/user/UserRepository.java
+++ b/src/main/java/com/example/dream_of_refrigerator/repository/user/UserRepository.java
@@ -12,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(@Param("email") String email);
 
     Optional<User> findByNickname(@Param("nickname") String nickname);
+    Optional<User> findById(@Param("id")Long id);
 }

--- a/src/main/java/com/example/dream_of_refrigerator/service/ingredient/IngredientService.java
+++ b/src/main/java/com/example/dream_of_refrigerator/service/ingredient/IngredientService.java
@@ -1,14 +1,10 @@
-package com.example.dream_of_refrigerator.service;
+package com.example.dream_of_refrigerator.service.ingredient;
 
 import com.example.dream_of_refrigerator.domain.ingredient.Ingredient;
-import com.example.dream_of_refrigerator.dto.BasicIngredientDto;
-import com.example.dream_of_refrigerator.dto.DetailIngredientDto;
-import com.example.dream_of_refrigerator.repository.IngredientRepository;
+import com.example.dream_of_refrigerator.dto.ingredient.BasicIngredientDto;
+import com.example.dream_of_refrigerator.dto.ingredient.DetailIngredientDto;
+import com.example.dream_of_refrigerator.repository.ingredient.IngredientRepository;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/dream_of_refrigerator/service/ingredient/IngredientService.java
+++ b/src/main/java/com/example/dream_of_refrigerator/service/ingredient/IngredientService.java
@@ -5,7 +5,7 @@ import com.example.dream_of_refrigerator.domain.user.User;
 import com.example.dream_of_refrigerator.domain.user.UserIngredient;
 import com.example.dream_of_refrigerator.dto.ingredient.BasicIngredientDto;
 import com.example.dream_of_refrigerator.dto.ingredient.DetailIngredientDto;
-import com.example.dream_of_refrigerator.dto.ingredient.UserIngredientDto;
+import com.example.dream_of_refrigerator.dto.ingredient.request.UserIngredientRequestDto;
 import com.example.dream_of_refrigerator.repository.ingredient.IngredientRepository;
 
 import com.example.dream_of_refrigerator.repository.ingredient.UserIngredientRepository;
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,8 +27,6 @@ public class IngredientService {
 
     // -> 모든 재료 조회 (기본 전체 조회)
     public List<BasicIngredientDto> findAllBasic() {
-        List<Ingredient> ingredients = ingredientRepository.findAll();
-        System.out.println(ingredients); // 확인을 위한 로그 출력
         return ingredientRepository.findAll().stream()
                 .map(ingredient -> new BasicIngredientDto(ingredient.getName())).collect(Collectors.toList());
     }
@@ -52,22 +49,22 @@ public class IngredientService {
                 .map(ingredient -> new BasicIngredientDto(ingredient.getName()))
                 .collect(Collectors.toList());
     }
-    public UserIngredient registerIngredients(Long ingredientId, UserIngredientDto userIngredientDto) {
+    public UserIngredient registerIngredients(Long ingredientId, UserIngredientRequestDto userIngredientRequestDto) {
         //재료를 등록하려고 하는 user
-        User user = userRepository.findById(userIngredientDto.UserId())
+        User user = userRepository.findById(userIngredientRequestDto.UserId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
         //등록하려는 ingredient
         Ingredient registerIngredient = ingredientRepository.findById(ingredientId);
         // 보관 방법 설정 (냉장,냉동)
-        registerIngredient.setIsRefrigerated(userIngredientDto.isRefrigerated());
-        registerIngredient.setIsFrozen(userIngredientDto.isFrozen());
+        registerIngredient.setIsRefrigerated(userIngredientRequestDto.isRefrigerated());
+        registerIngredient.setIsFrozen(userIngredientRequestDto.isFrozen());
         //등록하기
         UserIngredient userIngredient = UserIngredient.builder()
                 .user(user)
                 .ingredient(registerIngredient)
                 .purchaseDate(LocalDate.now())  //추가 날짜를 구매 날짜로 설정
-                .expirationDate(userIngredientDto.expiredDate()) //유통기한 설정
-                .quantity(userIngredientDto.quantity()) //개수 설정
+                .expirationDate(userIngredientRequestDto.expiredDate()) //유통기한 설정
+                .quantity(userIngredientRequestDto.quantity()) //개수 설정
                 .build();
 
         UserIngredient registeredIngredient = userIngredientRepository.save(userIngredient);

--- a/src/main/java/com/example/dream_of_refrigerator/service/ingredient/UserIngredientService.java
+++ b/src/main/java/com/example/dream_of_refrigerator/service/ingredient/UserIngredientService.java
@@ -1,0 +1,94 @@
+package com.example.dream_of_refrigerator.service.ingredient;
+
+import com.example.dream_of_refrigerator.domain.ingredient.Ingredient;
+import com.example.dream_of_refrigerator.domain.user.User;
+import com.example.dream_of_refrigerator.domain.user.UserIngredient;
+import com.example.dream_of_refrigerator.dto.ingredient.request.UserIngredientRequestDto;
+import com.example.dream_of_refrigerator.dto.ingredient.response.UserIngredientDetailResponseDto;
+import com.example.dream_of_refrigerator.dto.ingredient.response.UserIngredientResponseDto;
+import com.example.dream_of_refrigerator.repository.ingredient.IngredientRepository;
+import com.example.dream_of_refrigerator.repository.ingredient.UserIngredientRepository;
+import com.example.dream_of_refrigerator.repository.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class UserIngredientService {
+    private final UserIngredientRepository userIngredientRepository;
+    private final UserRepository userRepository;
+    private final IngredientRepository ingredientRepository;
+
+    public UserIngredientService(UserIngredientRepository userIngredientRepository, UserRepository userRepository, IngredientRepository ingredientRepository) {
+        this.userIngredientRepository = userIngredientRepository;
+        this.userRepository = userRepository;
+        this.ingredientRepository = ingredientRepository;
+    }
+
+    //사용자 냉장고에 있는 재료를 (expiration_date - purchase_date)의 차이가 짧은 순서로 정렬하여 조회
+    public List<UserIngredientResponseDto> findAll(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
+        return userIngredientRepository.findByUser(user).stream()
+                .sorted(Comparator.comparingLong(userIngredient ->
+                        Duration.between(userIngredient.getPurchaseDate().atStartOfDay(),
+                                userIngredient.getExpirationDate().atStartOfDay()).toDays()))
+                .map(userIngredient -> new UserIngredientResponseDto(
+                        userIngredient.getIngredient().getName()))
+                .collect(Collectors.toList());
+    }
+
+    public String findUserNickname(Long userId) {//{nickname}의 냉장고
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
+        return user.getNickname();
+    }
+
+    public UserIngredientDetailResponseDto findDetail(Long userId, Long ingredientId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
+
+        // 사용자의 재료 조회
+        UserIngredient userIngredient = userIngredientRepository.findByUserAndIngredientId(user, ingredientId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 재료를 찾을 수 없습니다."));
+
+        // 재료 정보 가져오기
+        Ingredient ingredient = userIngredient.getIngredient();
+
+        // UserIngredientDetailResponseDTO 반환
+        return new UserIngredientDetailResponseDto(
+                ingredient.getName(),
+                ingredient.getCategory(),
+                userIngredient.getQuantity(),
+                userIngredient.getPurchaseDate(),
+                userIngredient.getExpirationDate(),
+                ingredient.getIsFrozen(),
+                ingredient.getIsRefrigerated()
+        );
+
+    }
+
+//    public UserIngredient update(Long ingredientId, Long userIngredientId, UserIngredientRequestDto userIngredientRequestDto) {
+//        // 수정하려는 userIngredient를 조회
+//        UserIngredient userIngredient = userIngredientRepository.findById(userIngredientId)
+//                .orElseThrow(() -> new IllegalArgumentException("해당 재료 정보를 찾을 수 없습니다."));
+//
+//        // 재료 정보 수정 여부 확인
+//        Ingredient registerIngredient = ingredientRepository.findById(ingredientId)
+//        registerIngredient.setIsRefrigerated(userIngredientRequestDto.isRefrigerated());  // 냉장 여부 수정
+//        registerIngredient.setIsFrozen(userIngredientRequestDto.isFrozen());  // 냉동 여부 수정
+//
+//        // UserIngredient 정보 수정
+//        userIngredient.setIngredient(registerIngredient);  // 재료 수정
+//        userIngredient.setQuantity(userIngredientRequestDto.quantity());  // 수량 수정
+//        userIngredient.setExpirationDate(userIngredientRequestDto.expiredDate());  // 유통기한 수정
+//
+//        // 수정한 UserIngredient를 저장
+//        return userIngredientRepository.save(userIngredient);
+//    }
+}


### PR DESCRIPTION
### 완료 
냉장고 속 재료 전체 조회(닉네임,냉장고에 있는 재료 남은 기간 짧은 순서로 정렬하여 조회)
냉장고 속 재료 상세 조회(수량, 구매날짜(default:등록한 날), 유통기한, 냉장보관, 냉동보관)
재료 검색
재료 전체, 카테고리별 조회
재료 추가할 때 재료 정보 입력(수량, 구매날짜(default:등록한 날), 유통기한, 냉장보관, 냉동보관)


### <<<<헷갈리는 부분>>>>
1. 
feat:재료추가편집 기능구현
지금은 재료 정보 입력만 완료하면 냉장고에 보관된 재료로 처리됨
피그마에서 재료추가탭 맨 아래에
재료 정보 입력한 후에 냉장고에 한꺼번에 담을 재료 리스트를 어떻게 구현할지..

2.
냉장,냉동보관 필드의 위치를 어떻게 해야 할지(Ingredient로 하면 정보 입력,수정 때 Ingredient 테이블에 영향을 주는 것 같아서
냉장,냉동은 변경할 수 없도록
DB에 재료 등록할 때 보관방법도 등록해버릴지->이러면 사용자가 수정 못 함..
아니면
UserIngredient엔티티 필드로 냉장 냉동을 옮길지->이러면 사용자가 수정 가능
)


### 아직 미완료
냉장고 속 특정 재료 정보 수정
냉장고 속 재료 삭제
재료추가페이지 맨 아래에 선택완료 누르는 부분